### PR TITLE
Frameless window for OSX users.

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -9,7 +9,7 @@
     <link href="react/BunqDesktop.css" rel="stylesheet" type="text/css">
 </head>
 <body>
-
+<header></header>
 <main>
     <div class="container">
         <div id="app"/>

--- a/src/helpers/window.js
+++ b/src/helpers/window.js
@@ -74,7 +74,7 @@ export default (name, options) => {
 
   state = ensureVisibleOnSomeDisplay(restore());
 
-  win = new BrowserWindow(Object.assign({}, options, state));
+  win = new BrowserWindow(Object.assign({titleBarStyle: 'hidden'}, options, state));
 
   win.on('close', saveState);
 

--- a/src/scss/partials/base.scss
+++ b/src/scss/partials/base.scss
@@ -7,10 +7,15 @@ html {
     background-color: $backgroundColor;
 }
 
+header {
+    padding-top: 50px;
+    -webkit-user-select: none;
+    -webkit-app-region: drag;
+}
+
 body {
     background: url(https://static.useresponse.com/public/bunq/my-interface/bunq-colours-bar-2.png) no-repeat;
     height: calc(100vh - 50px);
-    padding-top: 50px;
     background-size: 100%;
     width: 100%;
 }


### PR DESCRIPTION
# Context
At the moment there is this ugly default title bar.

# What has been done
- Added a frameless window
- Made the header drag the screen.

# Notes
Looks pretty cool
![image](https://user-images.githubusercontent.com/6953846/31672014-9f29d9a6-b35b-11e7-95fb-7cbb914ba740.png)
