### PR TITLE
Electron update to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "cross-env": "^4.0.0",
         "css-loader": "^0.28.7",
         "date-fns": "^2.0.0-alpha.7",
-        "electron": "^1.8.2",
+        "electron": "^1.8.4",
         "electron-builder": "^20.2.0",
         "email-validator": "^1.1.1",
         "extract-text-webpack-plugin": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,9 +2699,9 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.24:
   version "1.3.26"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz#996427294861a74d9c7c82b9260ea301e8c02d66"
 
-electron@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.2.tgz#a817cd733c2972b3c7cc4f777caf6e424b88014d"
+electron@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.4.tgz#cca8d0e6889f238f55b414ad224f03e03b226a38"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
## Description
At this moment we are using Electron 1.8.2 since 1.8.2 some security issues have been fixed including a webview vulnerability (https://www.electronjs.org/blog/webview-fix).