### PR TITLE
Rename brew cask from bunq to bunqdesktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can directly search for 'bunqDesktop' in the Ubuntu store or use  the snap c
 
 #### [Brew Cask](https://caskroom.github.io/)
 
-`brew cask install bunq`
+`brew cask install bunqdesktop`
 
 #### [Chocolatey](https://chocolatey.org/packages/bunqdesktop) ![Download count for Chocolatey](https://img.shields.io/chocolatey/dt/bunqdesktop.svg)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can directly search for 'bunqDesktop' in the Ubuntu store or use  the snap c
 
 #### [Brew Cask](https://caskroom.github.io/)
 
-`brew cask install bunqdesktop`
+`brew cask install bunqcommunity-bunq`
 
 #### [Chocolatey](https://chocolatey.org/packages/bunqdesktop) ![Download count for Chocolatey](https://img.shields.io/chocolatey/dt/bunqdesktop.svg)
 


### PR DESCRIPTION
Depends on Homebrew/homebrew-cask#52373 to be merged