### PR TITLE
Fix application menu missing in menu items on macOS

### DIFF
--- a/src/menu/darwin_menu_templates.js
+++ b/src/menu/darwin_menu_templates.js
@@ -1,7 +1,7 @@
 import { app } from "electron";
 
 export default menus => {
-    if (process.platform !== "darwin") {
+    if (process.platform === "darwin") {
         menus.unshift({
             label: app.getName(),
             submenu: [


### PR DESCRIPTION
On macOS, the usual _application menu item_ is missing. Instead, items from the Edit menu are displayed in the first menu item titled **bunqDesktop**.

This PR resolves the issue, by properly adding the menu from **darwin_menu_templates.js**.

 - Closes bunqCommunity/bunqDesktop#480