### PR TITLE
Fix avatar sub icon misalignment for selected account list items (fixes #478, #490).

### DIFF
--- a/src/react/Components/AccountList/AccountListItem.jsx
+++ b/src/react/Components/AccountList/AccountListItem.jsx
@@ -28,9 +28,9 @@ const styles = {
         height: 60
     },
     avatarSub: {
-        position: "absolute",
-        left: 60,
-        bottom: 4
+        minWidth: 26,
+        marginLeft: -23,
+        marginTop: 40
     },
     secondaryIcon: {
         width: 26,


### PR DESCRIPTION
Fix misalignment of avatar sub icon (#490) and (coincidentally) seems to fix misaligned progress circle from issue #478 too.