### PR TITLE
Fix german translation for 'save'

### DIFF
--- a/src/react/Locales/de.json
+++ b/src/react/Locales/de.json
@@ -441,7 +441,7 @@
 	"Safekeeping fee calculator": "Aufbewahrungsgebühren-Rechner",
 	"Sandbox key": "Sandbox Schlüssel",
 	"Sandbox mode active": "Sandbox Modus aktiv",
-	"Save": "Sparen",
+	"Save": "Speichern",
 	"Save payment for later": "Zahlung für später speichern",
 	"Savings goal": "Sparziel",
 	"Savings goals": "Sparziele",


### PR DESCRIPTION
I've changed the translation for 'save' to fit the context it's being used in better.
 
