### PR TITLE
fix: set the electron path to fix electron-reload

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -88,7 +88,9 @@ log.transports.file.file = `${userDataPath}${path.sep}bunqDesktop.${env.name}.lo
 
 // hot reloading
 if (process.env.NODE_ENV === "development") {
-    require("electron-reload")(path.join(__dirname, `..${path.sep}app${path.sep}**`));
+    require("electron-reload")(path.join(__dirname, `..${path.sep}app${path.sep}**`), {
+        electron: path.join(__dirname, "../node_modules/electron"),
+    });
 }
 
 // set the correct path before the app loads


### PR DESCRIPTION
[//]: # (Excluding translations make sure this pull request is linked to an issue first! 
        This helps us keep track of all the changes when when we release a new version)

This should fix electron-reload. The `Electron could not be found. No hard resets for you!` message should be gone after this PR.
 
