### PR TITLE
chore: move deprecated componentWillMount calls to constructor

### DIFF
--- a/src/react/Components/Layout.jsx
+++ b/src/react/Components/Layout.jsx
@@ -67,8 +67,14 @@ class Layout extends React.Component {
             initialBunqJSClientRun: false
         };
 
-        this.activityTimer = null;
+        this.checkLanguageChange(this.props);
+
+        if (this.minuteTimer) {
+            clearInterval(this.minuteTimer);
+        }
         this.minuteTimer = null;
+
+        this.activityTimer = null;
 
         ipcRenderer.on("change-path", (event, path) => {
             const currentPath = this.props.history.location.pathname;
@@ -129,14 +135,6 @@ class Layout extends React.Component {
         // setup minute timer
         this.checkTime();
         this.minuteTimer = setInterval(this.checkTime, 5000);
-    }
-
-    componentWillMount() {
-        this.checkLanguageChange(this.props);
-
-        // unset the minuteTimer when set
-        if (this.minuteTimer) clearInterval(this.minuteTimer);
-        this.minuteTimer = null;
     }
 
     componentWillUpdate(nextProps) {

--- a/src/react/Pages/RulePage/RulePage.jsx
+++ b/src/react/Pages/RulePage/RulePage.jsx
@@ -15,23 +15,21 @@ import { openSnackbar } from "../../Actions/snackbar";
 class RulesPage extends React.Component {
     constructor(props, context) {
         super(props, context);
-        this.state = {
+
+        let initialState = {
             previewRuleCollection: null,
             previewUpdated: new Date(),
-
             checkedInitial: false,
-
-            initialRules: false
+            initialRules: false,
         };
-    }
 
-    componentWillMount() {
         const searchParams = new URLSearchParams(this.props.location.search);
         if (searchParams.has("value")) {
             const value = searchParams.get("value");
             const field = searchParams.get("field") || "DESCRIPTION";
 
-            this.setState({
+            initialState = {
+                ...initialState,
                 checkedInitial: true,
                 initialRules: [
                     {
@@ -39,28 +37,32 @@ class RulesPage extends React.Component {
                         field: field,
                         matchType: "CONTAINS",
                         value: value
-                    }
-                ]
-            });
+                    },
+                ],
+            };
         } else if (searchParams.has("amount")) {
             const amount = searchParams.get("amount");
             const match_type = searchParams.get("match_type") || "EXACTLY";
 
-            this.setState({
+            initialState = {
+                ...initialState,
                 checkedInitial: true,
                 initialRules: [
                     {
                         ruleType: "TRANSACTION_AMOUNT",
                         matchType: match_type,
-                        amount: amount
-                    }
-                ]
-            });
+                        amount: amount,
+                    },
+                ],
+            };
         } else {
-            this.setState({
-                checkedInitial: true
-            });
+            initialState = {
+                ...initialState,
+                checkedInitial: true,
+            };
         }
+
+        this.state = initialState;
     }
 
     updatePreview = ruleCollection => {


### PR DESCRIPTION
Remove the deprecated `componentWillMount` calls and pave the way to a newer React version.
 
