### PR TITLE
build: set electron builder nodeVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build": {
         "artifactName": "${productName}-${version}-${arch}.${ext}",
         "appId": "com.bunqdesktop",
+        "nodeVersion": "v12.4.0",
         "files": [
             "app/**/*",
             "node_modules/**/*",


### PR DESCRIPTION
Setting the electron builder nodeVersion in `package.json` seems to work with the Mac version. Just wondering why this is not supported in the Linux docker image. :thinking: 
