### PR TITLE
build: add Electron linux Dockerfile + auto build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,7 @@ before_script:
 script:
   - |
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      docker run --rm \
-        --env-file <(env | grep -v '\r' | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|(\b(?!TRAVIS_COMMIT_MESSAGE)TRAVIS)|APPVEYOR_|CSC_|_TOKEN|_KEY|BUILD_') \
-        -v ${PWD}:/project \
-        -v ~/.cache/electron:/root/.cache/electron \
-        -v ~/.cache/electron-builder:/root/.cache/electron-builder \
-        electronuserland/builder:wine \
-        /bin/bash -c "yarn --link-duplicates --pure-lockfile && yarn run release --linux"
+      bash ${TRAVIS_BUILD_DIR}/build/docker/electron-linux/run.sh
     else
       yarn run release -- --mac --win
     fi

--- a/build/docker/electron-linux/Dockerfile
+++ b/build/docker/electron-linux/Dockerfile
@@ -1,0 +1,35 @@
+FROM electronuserland/builder:wine
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# add yarn repo
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# install yarn and clean up
+RUN apt-get update && apt-get install -y yarn && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 12.14.0
+
+RUN mkdir $NVM_DIR -p
+
+# install nvm with node and npm
+RUN curl -sS -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.2/install.sh | bash
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# confirm installation
+RUN node -v
+RUN yarn -v

--- a/build/docker/electron-linux/run.sh
+++ b/build/docker/electron-linux/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+docker run --rm \
+  --env-file <(env | grep -v '\r' | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|(\b(?!TRAVIS_COMMIT_MESSAGE)TRAVIS)|APPVEYOR_|CSC_|_TOKEN|_KEY|BUILD_') \
+  -v ${TRAVIS_BUILD_DIR}:/project \
+  -v ~/.cache/electron:/root/.cache/electron \
+  -v ~/.cache/electron-builder:/root/.cache/electron-builder \
+  $(docker build -q .) \
+  /bin/bash -c 'yarn --link-duplicates --pure-lockfile && yarn run release --linux'


### PR DESCRIPTION
Adds an Electron builder Docker file for Linux images.

This Docker file includes downloading nvm and installing node 12 LTS so that all environments are running the same version.
