### PR TITLE
fix: devtools import in production build

### DIFF
--- a/src/helpers/devtools.js
+++ b/src/helpers/devtools.js
@@ -1,6 +1,7 @@
-import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from "electron-devtools-installer";
-
 export default async () => {
+  const installExtension = require("electron-devtools-installer");
+  const { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } = installExtension;
+
   await Promise.all([
     installExtension(REACT_DEVELOPER_TOOLS),
     installExtension(REDUX_DEVTOOLS),


### PR DESCRIPTION
[//]: # (Add the correct issue number so it can be closed automatically when required)        
 - Closes bunqCommunity/bunqDesktop#556
 
Using a CommonJS require fixes the devtools include in production builds. Still works on development environments as well.

