### PR TITLE
fix: Not all Mastercard actions are negative amounts

### DIFF
--- a/src/react/Components/ListItems/MasterCardActionListItem.jsx
+++ b/src/react/Components/ListItems/MasterCardActionListItem.jsx
@@ -58,7 +58,7 @@ class MasterCardActionListItem extends React.Component {
         const displayName = masterCardAction.counterparty_alias.display_name;
         let paymentAmount = masterCardAction.getAmount();
         paymentAmount = paymentAmount > 0 ? paymentAmount * -1 : paymentAmount;
-        const formattedPaymentAmount = formatMoney(paymentAmount, true);
+        const formattedPaymentAmount = formatMoney(paymentAmount, masterCardAction.payment_status !== "CREDIT_TRANSFER");
         const secondaryText = masterCardActionParser(masterCardAction, t);
 
         const defaultImage = defaultMastercardImage(masterCardAction);

--- a/src/react/Components/MoneyAmountLabel.jsx
+++ b/src/react/Components/MoneyAmountLabel.jsx
@@ -98,7 +98,7 @@ class MoneyAmountLabel extends React.Component {
         const { theme, style, info } = this.props;
 
         // switch between incoming/outgoing colors
-        const paymentColor =
+        let paymentColor =
             info.amount.value < 0 ? theme.palette.common.sentPayment : theme.palette.common.receivedPayment;
 
         return {
@@ -124,6 +124,13 @@ class MoneyAmountLabel extends React.Component {
                     ...style
                 };
             case "CLEARING_REFUND":
+                if (info.payment_status === "CREDIT_TRANSFER") {
+                    return {
+                        color: theme.palette.common.receivedPayment,
+                        ...style
+                    };
+                }
+
                 return {
                     color: theme.palette.masterCardAction.refunded,
                     ...theme.styles.masterCardAction.refunded,

--- a/src/react/Models/MasterCardAction.ts
+++ b/src/react/Models/MasterCardAction.ts
@@ -28,6 +28,7 @@ export default class MasterCardAction implements Event {
     private _description: string;
     private _authorisation_status: string;
     private _authorisation_type: string;
+    private _payment_status: string;
     private _pan_entry_mode_user: PanEntryModeUser;
     private _city: string;
     private _alias: PaymentAlias;
@@ -145,6 +146,9 @@ export default class MasterCardAction implements Event {
     }
     get authorisation_type(): string {
         return this._authorisation_type;
+    }
+    get payment_status(): string {
+        return this._payment_status;
     }
     get pan_entry_mode_user(): PanEntryModeUser {
         return this._pan_entry_mode_user;

--- a/src/react/Pages/MasterCardActionInfo.jsx
+++ b/src/react/Pages/MasterCardActionInfo.jsx
@@ -133,7 +133,7 @@ class MasterCardActionInfo extends React.Component {
             paymentAmount = paymentAmount > 0 ? paymentAmount * -1 : paymentAmount;
             const paymentDate = humanReadableDate(masterCardAction.created);
             const paymentDateUpdated = humanReadableDate(masterCardAction.updated);
-            const formattedPaymentAmount = formatMoney(paymentAmount, true);
+            const formattedPaymentAmount = formatMoney(paymentAmount, masterCardAction.payment_status !== "CREDIT_TRANSFER");
             const paymentLabel = masterCardActionText(masterCardAction, t);
 
             const settledText = t("Settled");


### PR DESCRIPTION
[//]: # (Excluding translations make sure this pull request is linked to an issue first! 
        This helps us keep track of all the changes when when we release a new version)

[//]: # (Add the correct issue number so it can be closed automatically when required)        
 - Closes bunqCommunity/bunqDesktop#533

By treating Mastercard actions with the `payment_status` of `CREDIT_TRANSFER` as received payments we can make sure they are displayed as positive amounts.
 
