### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can directly search for 'bunqDesktop' in the Ubuntu store or use  the snap c
 
 #### [Brew Cask](https://caskroom.github.io/)
 
-`brew cask install bunqcommunity-bunq`
+`brew install --cask bunqcommunity-bunq`
 
 #### [Chocolatey](https://chocolatey.org/packages/bunqdesktop) ![Download count for Chocolatey](https://img.shields.io/chocolatey/dt/bunqdesktop.svg)
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524